### PR TITLE
feat: relese note support multiline

### DIFF
--- a/.github/workflows/githubactionsbuilds.yml
+++ b/.github/workflows/githubactionsbuilds.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           name: ModsOutput
           path: Build/ModsOutput
+      - name: Deal the Multiline
+        id: multi-line
+        run: echo "::set-output name=RELEASE_NOTES::${{ github.event.inputs.releaseNotes }}".replace("\n", "%0A")
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -70,7 +73,7 @@ jobs:
           tag_name: ${{github.event.inputs.version}}
           release_name: ${{github.event.inputs.version}}
           body: |
-            ${{ github.event.inputs.releaseNotes }}
+            ${{ steps.multi-line.outputs.RELEASE_NOTES  }}
           draft: false
           prerelease: false
 


### PR DESCRIPTION
## Case
### input
* version: `5.5.0`
* release notes: `line1\nline2\nline3\nline4`
### result
![image](https://user-images.githubusercontent.com/20685961/141988698-5611d846-851c-44a0-8ef5-5dfca838d01e.png)


## Refer
* set-output Truncates Multiline Strings[^1] 
* set-output in action[^2]

[^1]: https://github.community/t/set-output-truncates-multiline-strings/16852
[^2]: https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions